### PR TITLE
Added CMake instructions to suppress log window for release builds.

### DIFF
--- a/PadCast/CMakeLists.txt
+++ b/PadCast/CMakeLists.txt
@@ -1,15 +1,24 @@
-﻿# CMakeList.txt : CMake project for PadCast, include source and define
-# project specific logic here.
-#
-
-# Add source to this project's executable.
-add_executable (PadCast 
+﻿# Add source to this project's executable.
+add_executable (PadCast
     "src/PadCast.cpp" 
     "include/PadCast.h" 
     "include/mini/ini.h" 
     "include/config.h"
     "src/config.cpp"
+    "src/winmain_proxy.cpp"
 )
+
+# Suppress Log window for non-debug builds
+set_target_properties(PadCast PROPERTIES
+    WIN32_EXECUTABLE $<NOT:$<CONFIG:Debug>>
+)
+
+# Save this for later for Linux builds
+#if (WIN32)
+#  target_link_options(PadCast PRIVATE 
+#    "$<$<NOT:$<CONFIG:Debug>>:-Wl,--subsystem,windows>"
+#  )
+#endif()
 
 # Add include directories
 target_include_directories(PadCast PRIVATE 

--- a/PadCast/src/winmain_proxy.cpp
+++ b/PadCast/src/winmain_proxy.cpp
@@ -1,0 +1,7 @@
+#if defined(_WIN32)
+#include <windows.h>
+extern int main(int argc, char** argv);
+int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd) {
+    return main(__argc, __argv);
+}
+#endif


### PR DESCRIPTION
Added CMake instructions to suppress log window for release builds. It will still open when building debug builds. I couldn't get the proxy from raylib to work so I found and am using winmain_proxy.cpp.